### PR TITLE
Added an "About MyData" menu item to system tray icon menu, which

### DIFF
--- a/mydata/views/taskbaricon.py
+++ b/mydata/views/taskbaricon.py
@@ -46,6 +46,7 @@ class MyDataTaskBarIcon(TaskBarIcon):
         # self.Bind(wx.EVT_TASKBAR_LEFT_DOWN, self.OnTaskBarLeftClick)
 
         self.menu = None
+        self.aboutMyDataMenuItem = None
         self.myTardisSyncMenuItem = None
         self.myTardisMainWindowMenuItem = None
         self.myTardisSettingsMenuItem = None
@@ -58,6 +59,17 @@ class MyDataTaskBarIcon(TaskBarIcon):
         when the user clicks on MyData's system tray (or menubar) icon.
         """
         self.menu = wx.Menu()
+
+        self.aboutMyDataMenuItem = wx.MenuItem(
+            self.menu, wx.NewId(), "About MyData")
+        if wx.version().startswith("3.0.3.dev"):
+            self.menu.Append(self.aboutMyDataMenuItem)
+        else:
+            self.menu.AppendItem(self.aboutMyDataMenuItem)
+        self.Bind(wx.EVT_MENU, wx.GetApp().OnAbout,
+                  self.aboutMyDataMenuItem, self.aboutMyDataMenuItem.GetId())
+
+        self.menu.AppendSeparator()
 
         self.myTardisSyncMenuItem = wx.MenuItem(
             self.menu, wx.NewId(), "MyTardis Sync")


### PR DESCRIPTION
is a menubar icon menu on Mac OS X.  Previously, the first menu
item was "MyTardis Sync", and it was possible to accidentally
select that menu item while clicking on the MyData menubar icon
(just to open the menu to have a look), because the "MyTardis Sync"
menu item was so close to the menubar icon.  Now if a Mac OS X
user accidentally clicks the first menu item while opening the menu,
MyData will report its version number in an About dialog.