### PR TITLE
Fixed issue with unwanted busy cursor - closing a modal dialog

### DIFF
--- a/mydata/controllers/folders.py
+++ b/mydata/controllers/folders.py
@@ -218,7 +218,8 @@ class FoldersController(object):
         except:
             needToRestartBusyCursor = False
         dlg.ShowModal()
-        if needToRestartBusyCursor:
+        if needToRestartBusyCursor and not self.IsShuttingDown() \
+                and wx.GetApp().PerformingLookupsAndUploads():
             wx.BeginBusyCursor()
         if event.icon == wx.ICON_ERROR:
             self.SetShowingErrorDialog(False)
@@ -607,9 +608,12 @@ class FoldersController(object):
                 sshControlMasterPool.ShutDown()
 
         if self.testRun:
-            numVerificationsCompleted = self.verificationsModel.GetCompletedCount()
-            numVerifiedUploads = self.verificationsModel.GetFoundVerifiedCount()
-            numFilesNotFoundOnServer = self.verificationsModel.GetNotFoundCount()
+            numVerificationsCompleted = \
+                self.verificationsModel.GetCompletedCount()
+            numVerifiedUploads = \
+                self.verificationsModel.GetFoundVerifiedCount()
+            numFilesNotFoundOnServer = \
+                self.verificationsModel.GetNotFoundCount()
             numFullSizeUnverifiedUploads = \
                 self.verificationsModel.GetFoundUnverifiedFullSizeCount()
             numIncompleteUploads = \


### PR DESCRIPTION
returned the cursor to the state it was in before the dialog
appeared (e.g. busy), but this is unwanted if the uploads
have completed by the time the user closes the modal dialog.