### PR TITLE
Disabling Pylint warnings generated when building against latest

### DIFF
--- a/mydata/MyData.py
+++ b/mydata/MyData.py
@@ -36,6 +36,7 @@ else:
     from wx import EVT_TASKBAR_LEFT_UP
     from wx import EVT_TASKBAR_LEFT_DOWN
     # pylint: disable=import-error
+    # pylint: disable=no-name-in-module
     from wx.aui import AuiNotebook
     from wx.aui import AUI_NB_TOP
     from wx.aui import EVT_AUINOTEBOOK_PAGE_CHANGING

--- a/mydata/views/settings.py
+++ b/mydata/views/settings.py
@@ -23,8 +23,8 @@ if wx.version().startswith("3.0.3.dev"):
     from wx.lib.agw.aui import AUI_NB_TOP
 else:
     import wx.lib.masked
-    from wx.aui import AuiNotebook
-    from wx.aui import AUI_NB_TOP
+    from wx.aui import AuiNotebook  # pylint: disable=no-name-in-module
+    from wx.aui import AUI_NB_TOP  # pylint: disable=no-name-in-module
 
 from mydata.utils import BeginBusyCursorIfRequired
 from mydata.utils import EndBusyCursorIfRequired


### PR DESCRIPTION
version of wxPython Phoenix, used in AppVeyor build.