### PR TITLE
Using git's old commit datetime format "%ci", instead of the new

### DIFF
--- a/mydata/__init__.py
+++ b/mydata/__init__.py
@@ -23,7 +23,7 @@ else:
     LATEST_COMMIT = LINE.split(" ")[1]
     GIT = distutils.spawn.find_executable("git")
     LATEST_COMMIT_DATETIME = subprocess.check_output(
-        [GIT, "log", "-1", "--pretty=format:%cI"])
+        [GIT, "log", "-1", "--pretty=format:%ci"])
     with open("mydata/commitdef.py", 'w') as commitdef:
         commitdef.write('"""\n')
         commitdef.write('commitdef.py\n')


### PR DESCRIPTION
"%cI" (strict ISO 8601), because the new format option isn't
supported by old versions of git, e.g. as found on RHEL6.